### PR TITLE
Fix checksuming check when same checksums are not in adjacent lines

### DIFF
--- a/tests/t/check
+++ b/tests/t/check
@@ -12,7 +12,7 @@ unless($expected_hosts) {
 }
 `mk-table-checksum  --databases=test $expected_hosts --count --trim > checksum.log`;
 
-my $checksum_uniq=`cat checksum.log | awk '{print \$7}' | grep -v CHECKSUM | uniq | wc  | awk {'print \$1}'`;
+my $checksum_uniq=`cat checksum.log | awk '{print \$7}' | grep -v CHECKSUM | sort -u | wc  | awk '{print \$1}'`;
 chomp($checksum_uniq);
 
 if($checksum_uniq ne '1') {


### PR DESCRIPTION
sample result
DATABASE TABLE CHUNK HOST      ENGINE      COUNT         CHECKSUM TIME WAIT STAT  LAG
test     t1        0 127.0.0.1 InnoDB          2         f54c7385    0    0 NULL NULL
test     t1        0 127.0.0.1 InnoDB          2         xxxxxxxx    0    0 NULL NULL
test     t1        0 127.0.0.1 InnoDB          2         f54c7385    0    0 NULL NULL
test     t1        0 127.0.0.1 InnoDB          2         f54c7385    0    0 NULL NULL
