### PR TITLE
add helper to block/release user in Shlomi Noach's way

### DIFF
--- a/lib/MHA/DBHelper.pm
+++ b/lib/MHA/DBHelper.pm
@@ -103,6 +103,14 @@ use constant Flush_Tables_With_Read_Lock_SQL => "FLUSH TABLES WITH READ LOCK";
 use constant Unlock_Tables_SQL               => "UNLOCK TABLES";
 use constant Repl_User_SQL =>
   "SELECT Repl_slave_priv AS Value FROM mysql.user WHERE user = ?";
+use constant Select_User_Regexp_SQL     => "SELECT user, host, password FROM mysql.user WHERE user REGEXP ? AND host REGEXP ?";
+use constant Set_Password_SQL           => "SET PASSWORD FOR ?\@? = ?";
+
+use constant Old_Password_Length          => 16;
+use constant Blocked_Empty_Password       => '?' x 41;
+use constant Blocked_Old_Password_Head    => '~' x 25;
+use constant Blocked_New_Password_Regexp  => qr/^[0-9a-fA-F]{40}\*$/o;
+use constant Released_New_Password_Regexp => qr/^\*[0-9a-fA-F]{40}$/o;
 
 sub new {
   my $class = shift;
@@ -741,6 +749,63 @@ sub master_pos_wait($$$) {
   $sth->execute( $binlog_file, $binlog_pos );
   my $href = $sth->fetchrow_hashref;
   return $href->{Result};
+}
+
+# see http://code.openark.org/blog/mysql/blocking-user-accounts
+sub _blocked_password {
+  my $password = shift;;
+  if ( $password eq '' ) {
+    return Blocked_Empty_Password;
+  }
+  elsif ( length( $password ) == Old_Password_Length ) {
+    return Blocked_Old_Password_Head . $password;
+  }
+  elsif ( $password =~ Released_New_Password_Regexp ) {
+    return join( "", reverse( split //, $password ) );
+  }
+  else {
+    return;
+  }
+}
+sub _released_password {
+  my $password = shift;
+  if ( $password eq Blocked_Empty_Password ) {
+    return '';
+  }
+  elsif ( index( $password, Blocked_Old_Password_Head ) == 0 ) {
+    return substr( $password, length( Blocked_Old_Password_Head ) );
+  }
+  elsif ( $password =~ Blocked_New_Password_Regexp ) {
+    return join( "", reverse( split //, $password ) );
+  }
+  else {
+    return;
+  }
+}
+sub _block_release_user_by_regexp {
+  my ($dbh, $user, $host, $block) = @_;
+  my $users_to_block = $dbh->selectall_arrayref( Select_User_Regexp_SQL, { Slice => {} }, $user, $host );
+  my $failure = 0;
+  for my $u ( @{$users_to_block} ) {
+    my $password = $block ? _blocked_password( $u->{password} ) : _released_password( $u->{password} );
+    if (defined $password) {
+      my $ret = $dbh->do(Set_Password_SQL, undef, $u->{user}, $u->{host}, $password);
+      unless ($ret eq "0E0") {
+        $failure++;
+      }
+    }
+  }
+  return $failure;
+}
+
+sub block_user_regexp {
+  my ($self, $user, $host) = @_;
+  return _block_release_user_by_regexp( $self->{dbh}, $user, $host, 1);
+}
+
+sub release_user_regexp {
+  my ($self, $user, $host) = @_;
+  return _block_release_user_by_regexp( $self->{dbh}, $user, $host, 0);
 }
 
 1;


### PR DESCRIPTION
master_ip_online_change script suggests the following steps in freezing phase:

```
## Gracefully killing connections on the current master
#1. Set read_only= 1 on the new master
#2. DROP USER so that no app user can establish new connections
#3. Set read_only= 1 on the current master
#4. Kill current queries
# * Any database access failure will result in script die.
```

In step 2, what we need is blocking users rather than dropping users. Dropping users is one way to block and requires management effort such as dump and import. Why not change the password which effectively disable login? In Shlomi Noach's way as described in this link http://code.openark.org/blog/mysql/blocking-user-accounts

So add two helpers to easy hook script writers.

Test cases snippet:

set_password($dbh, '');
$ret = _block_release_user_by_regexp($dbh,'abc','localhost',1);
ok( $ret == 0 && is_blocked('abc', ''), 'block empty');
_block_release_user_by_regexp($dbh,'abc','localhost',0);
ok( $ret == 0 && is_released('abc', ''), 'release empty');

set_password($dbh, '123');
$ret = _block_release_user_by_regexp($dbh,'abc','localhost',1);
ok($ret == 0 && is_blocked('abc', '123'), 'block new');
$ret = _block_release_user_by_regexp($dbh,'abc','localhost',0);
ok($ret == 0 && is_released('abc', '123'), 'release new');

sub is_blocked {
  my ($user,$password) = @_;
  DBI->connect('dbi:mysql:', $user, $password, {PrintError=>0});
  return 1 if $DBI::err == 1045;
}
sub is_released {
  my ($user,$password) = @_;
  DBI->connect('dbi:mysql:', $user, $password, {PrintError=>0});
  return 1 if $DBI::err == 0;
}
sub set_password {
  my ($dbh, $plain) = @_;
  my $rs = $dbh->do("set password for 'abc'\@'localhost' = password('$plain')");
}
