### PR TITLE
Update ServerManager.pm

### DIFF
--- a/lib/MHA/ServerManager.pm
+++ b/lib/MHA/ServerManager.pm
@@ -28,6 +28,7 @@ use MHA::DBHelper;
 use MHA::Server;
 use MHA::ManagerConst;
 use Parallel::ForkManager;
+use Tie::RefHash;
 
 sub new {
   my $class = shift;
@@ -933,6 +934,8 @@ sub identify_latest_slaves($$) {
   my $log    = $self->{logger};
   my @slaves = $self->get_alive_slaves();
   my @latest = ();
+  my %latest_slave ;
+  tie %latest_slave, 'Tie::RefHash';  
   foreach (@slaves) {
     my $a = $latest[0]{Master_Log_File};
     my $b = $latest[0]{Read_Master_Log_Pos};
@@ -946,8 +949,8 @@ sub identify_latest_slaves($$) {
       )
       )
     {
-      @latest = ();
-      push( @latest, $_ );
+      $exec_master_diff = $_->{Read_Master_Log_Pos} - $_->{Exec_Master_Log_Pos};
+      $latest_slave{$_} = $exec_master_diff;
     }
     elsif (
       $find_oldest
@@ -959,15 +962,22 @@ sub identify_latest_slaves($$) {
       )
       )
     {
-      @latest = ();
-      push( @latest, $_ );
+      $exec_master_diff = $_->{Read_Master_Log_Pos} - $_->{Exec_Master_Log_Pos};
+      $latest_slave{$_} = $exec_master_diff;
     }
     elsif ( ( $_->{Master_Log_File} eq $latest[0]{Master_Log_File} )
       && ( $_->{Read_Master_Log_Pos} == $latest[0]{Read_Master_Log_Pos} ) )
     {
-      push( @latest, $_ );
+      $exec_master_diff = $_->{Read_Master_Log_Pos} - $_->{Exec_Master_Log_Pos};
+      $latest_slave{$_} = $exec_master_diff;
     }
   }
+  
+  @latest=();
+  foreach (sort { $latest_slave{$b} <=> $latest_slave{$a} } keys %latest_slave){
+        push( @latest, $_ );
+  }
+  @latest = reverse(@latest);  
   foreach (@latest) {
     $_->{latest} = 1 if ( !$find_oldest );
     $_->{oldest} = 1 if ($find_oldest);


### PR DESCRIPTION
Changed function identify_latest_slaves to return latest slaves list in an order based on Seconds_Behind_Master at the time of fail-over instead of slave's order in the config file if Seconds_Behind_Master value is different on both the slaves.
