### PR TITLE
Disable setting MASTER_AUTO_POSITION=0 which is not compatible with

### DIFF
--- a/lib/MHA/DBHelper.pm
+++ b/lib/MHA/DBHelper.pm
@@ -133,6 +133,7 @@ sub new {
     dbh           => undef,
     connection_id => undef,
     has_gtid      => undef,
+	is_mariadb    => undef,
     @_,
   };
   return bless $self, $class;
@@ -293,7 +294,12 @@ sub get_num_workers($) {
 
 sub get_version($) {
   my $self = shift;
-  return MHA::SlaveUtil::get_version( $self->{dbh} );
+  my $value = MHA::SlaveUtil::get_version( $self->{dbh} );
+  if ($value =~ /MariaDB/)
+  {
+  	$self->{is_mariadb} = 1;
+  }
+  return $value;
 }
 
 sub is_relay_log_purge($) {

--- a/lib/MHA/ServerManager.pm
+++ b/lib/MHA/ServerManager.pm
@@ -1342,7 +1342,7 @@ sub change_master_and_start_slave {
     ? $master->{ip}
     : $master->{hostname};
 
-  if ( $target->{has_gtid} and $self->is_gtid_auto_pos_enabled() ) {
+  if ( $self->is_gtid_auto_pos_enabled() && !$target->{is_mariadb} ) {
     $dbhelper->change_master_gtid( $addr, $master->{port},
       $master->{repl_user}, $master->{repl_password} );
   }


### PR DESCRIPTION
Disable setting MASTER_AUTO_POSITION=0 which is not compatible with MariaDB 10.
Set MASTER_AUTO_POSITION to 1 only if gtid_mode=1 as it is required :

Extract from official documentation: http://dev.mysql.com/doc/refman/5.6/en/change-master-to.html
"gtid_mode must also be enabled before issuing CHANGE MASTER TO ... MASTER_AUTO_POSITION = 1. Otherwise, the statement fails with an error."
