### PR TITLE
Use get_hostinfo() instead of hostname in failover messages

### DIFF
--- a/lib/MHA/ServerManager.pm
+++ b/lib/MHA/ServerManager.pm
@@ -1417,12 +1417,12 @@ sub get_current_servers_ascii {
   my $orig_master  = shift;
   my @alive_slaves = $self->get_alive_slaves();
 
-  my $str = "$orig_master->{hostname}:$orig_master->{port} (current master)";
+  my $str = $orig_master->get_hostinfo() . " (current master)";
   $str .= " ($orig_master->{node_label})"
     if ( $orig_master->{node_label} );
   $str .= "\n";
   foreach my $slave (@alive_slaves) {
-    $str .= " +--" . "$slave->{hostname}:$slave->{port}";
+    $str .= " +--" . $slave->get_hostinfo();
     $str .= " ($slave->{node_label})" if ( $slave->{node_label} );
     $str .= "\n";
   }
@@ -1454,18 +1454,18 @@ sub print_servers_migration_ascii {
   $str .= $self->get_current_servers_ascii($orig_master);
 
   $str .= "To:\n";
-  $str .= "$new_master->{hostname}:$new_master->{port} (new master)";
+  $str .= $new_master->get_hostinfo() . " (new master)";
   $str .= " ($new_master->{node_label})"
     if ( $new_master->{node_label} );
   $str .= "\n";
   foreach my $slave (@alive_slaves) {
     next if ( $slave->{id} eq $new_master->{id} );
-    $str .= " +--" . "$slave->{hostname}:$slave->{port}";
+    $str .= " +--" . $slave->get_hostinfo();
     $str .= " ($slave->{node_label})" if ( $slave->{node_label} );
     $str .= "\n";
   }
   if ($orig_master_is_new_slave) {
-    $str .= " +--" . "$orig_master->{hostname}:$orig_master->{port}";
+    $str .= " +--" . $orig_master->get_hostinfo();
     $str .= " ($orig_master->{node_label})" if ( $orig_master->{node_label} );
     $str .= "\n";
   }


### PR DESCRIPTION
In multi-instance environment, we would like to check not only the hostname but also the port number.
