### PR TITLE
Rewrite a shebang line of each bin/* scripts if REWRITE_SHEBANG is set

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,6 +15,22 @@ requires 'MHA::NodeConst';
 license 'GPL v2';
 author 'Yoshinori Matsunobu <Yoshinori.Matsunobu@gmail.com>';
 
-install_script(glob 'bin/*');
+if ($ENV{REWRITE_SHEBANG}) {
+    mkdir 'xbin';
+    for my $bin (glob 'bin/*') {
+        (my $xbin = $bin) =~ s{^bin/}{xbin/};
+        open my $in,  '<', $bin  or die $!;
+        open my $out, '>', $xbin or die $!;
+        while (<$in>) {
+            s|^#!/usr/bin/env perl|#!perl|; # so MakeMaker can fix it
+            print $out $_;
+        }
+        close $in;
+        close $out;
+    }
+    install_script(glob 'xbin/*');
+} else {
+    install_script(glob 'bin/*');
+}
 auto_install;
 WriteAll;


### PR DESCRIPTION
ExtUtils::MakeMaker rewirtes #/usr/bin/perl or #!perl but NOT
# !/usr/bin/env perl, so mandatorily rewrite shebang if environment variable

REWRITE_SHEBANG is set.
- https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/58
