### PR TITLE
Use InnoDB for ping insert

### DIFF
--- a/bin/masterha_secondary_check
+++ b/bin/masterha_secondary_check
@@ -107,7 +107,7 @@ foreach my $monitoring_server (@monitoring_servers) {
           "ssh $MHA::ManagerConst::SSH_OPT_CHECK -p $ssh_port $ssh_user_host \'"
         . "/usr/bin/mysql -u$master_user -p$master_password -h$master_host "
         . "-e \"CREATE DATABASE IF NOT EXISTS infra; "
-        . "CREATE TABLE IF NOT EXISTS infra.chk_masterha (\\`key\\` tinyint NOT NULL primary key,\\`val\\` int(10) unsigned NOT NULL DEFAULT '0'\) engine=MyISAM; "
+        . "CREATE TABLE IF NOT EXISTS infra.chk_masterha (\\`key\\` tinyint NOT NULL primary key,\\`val\\` int(10) unsigned NOT NULL DEFAULT '0'\) engine=InnoDB; "
         . "INSERT INTO infra.chk_masterha values (1,unix_timestamp()) ON DUPLICATE KEY UPDATE val=unix_timestamp()\"\'";
       my $sigalrm_timeout = 3;
       eval {

--- a/lib/MHA/HealthCheck.pm
+++ b/lib/MHA/HealthCheck.pm
@@ -296,7 +296,7 @@ sub ping_insert($) {
     $dbh->{RaiseError} = 1;
     $dbh->do("CREATE DATABASE IF NOT EXISTS infra");
     $dbh->do(
-"CREATE TABLE IF NOT EXISTS infra.chk_masterha (`key` tinyint NOT NULL primary key,`val` int(10) unsigned NOT NULL DEFAULT '0') engine=MyISAM"
+"CREATE TABLE IF NOT EXISTS infra.chk_masterha (`key` tinyint NOT NULL primary key,`val` int(10) unsigned NOT NULL DEFAULT '0') engine=InnoDB"
     );
     $dbh->do(
 "INSERT INTO infra.chk_masterha values (1,unix_timestamp()) ON DUPLICATE KEY UPDATE val=unix_timestamp()"


### PR DESCRIPTION
I'd like to change ping_insert's engine to InnoDB. It's useful for simulating disk failure.
