### PR TITLE
Ignore event scheduler when checking long updates

### DIFF
--- a/lib/MHA/DBHelper.pm
+++ b/lib/MHA/DBHelper.pm
@@ -763,6 +763,7 @@ sub get_threads_util {
     next if ( defined($query_time) && $query_time < $running_time_threshold );
     next if ( defined($command)    && $command =~ /^Binlog Dump/ );
     next if ( defined($user)       && $user eq "system user" );
+    next if ( defined($user)       && $user eq "event_scheduler" );
 
     if ( $type >= 1 ) {
       next if ( defined($command) && $command eq "Sleep" );


### PR DESCRIPTION
https://code.google.com/p/mysql-master-ha/issues/detail?id=28

The event scheduler shouldn't prevent a failover, and should be ignored by the long updates check.  

The event status needn't be monitored by MHA, and should be handled on failover via the hooks in the master_ip_failover_script and master_ip_online_change_script.
