### PR TITLE
Report config file parsing more clearly

### DIFF
--- a/lib/MHA/Config.pm
+++ b/lib/MHA/Config.pm
@@ -337,7 +337,7 @@ sub read_config($) {
 
   if ( -f $global_configfile ) {
     my $global_cfg = Config::Tiny->read($global_configfile)
-      or croak "$global_configfile:$!\n";
+      or croak "Unable to parse/read configuration file: $configfile: $!\n";
 
     $log->info("Reading default configuration from $self->{globalfile}..")
       if ($log);


### PR DESCRIPTION
I had an incorrect config file and this change makes the reporting a bit clearer.
