### PR TITLE
add compatibility with MariaDB & Percona Server's 'enforce_storage_engine'

### DIFF
--- a/bin/masterha_secondary_check
+++ b/bin/masterha_secondary_check
@@ -107,7 +107,7 @@ foreach my $monitoring_server (@monitoring_servers) {
           "ssh $MHA::ManagerConst::SSH_OPT_CHECK -p $ssh_port $ssh_user_host \'"
         . "/usr/bin/mysql -u$master_user -p$master_password -h$master_host "
         . "-e \"CREATE DATABASE IF NOT EXISTS infra; "
-        . "CREATE TABLE IF NOT EXISTS infra.chk_masterha (\\`key\\` tinyint NOT NULL primary key,\\`val\\` int(10) unsigned NOT NULL DEFAULT '0'\) engine=InnoDB; "
+        . "CREATE TABLE IF NOT EXISTS infra.chk_masterha (\\`key\\` tinyint NOT NULL primary key,\\`val\\` int(10) unsigned NOT NULL DEFAULT '0'\); "
         . "INSERT INTO infra.chk_masterha values (1,unix_timestamp()) ON DUPLICATE KEY UPDATE val=unix_timestamp()\"\'";
       my $sigalrm_timeout = 3;
       eval {

--- a/lib/MHA/HealthCheck.pm
+++ b/lib/MHA/HealthCheck.pm
@@ -296,7 +296,7 @@ sub ping_insert($) {
     $dbh->{RaiseError} = 1;
     $dbh->do("CREATE DATABASE IF NOT EXISTS infra");
     $dbh->do(
-"CREATE TABLE IF NOT EXISTS infra.chk_masterha (`key` tinyint NOT NULL primary key,`val` int(10) unsigned NOT NULL DEFAULT '0') engine=InnoDB"
+"CREATE TABLE IF NOT EXISTS infra.chk_masterha (`key` tinyint NOT NULL primary key,`val` int(10) unsigned NOT NULL DEFAULT '0')"
     );
     $dbh->do(
 "INSERT INTO infra.chk_masterha values (1,unix_timestamp()) ON DUPLICATE KEY UPDATE val=unix_timestamp()"

--- a/tests/t/init.sh
+++ b/tests/t/init.sh
@@ -33,7 +33,7 @@ mysql $S1 -e "source grant_nopass.sql"
 mysql $S2 -e "source grant_nopass.sql"
 mysql $S3 -e "source grant_nopass.sql"
 mysql $S4 -e "source grant_nopass.sql"
-mysql $M test -e "create table t1 (id int primary key, value int, value2 text) engine=innodb; insert into t1 values(1, 100, 'abc');"
+mysql $M test -e "create table t1 (id int primary key, value int, value2 text); insert into t1 values(1, 100, 'abc');"
 
 wait_until_count $0 $S1P 1
 wait_until_count $0 $S2P 1


### PR DESCRIPTION
the test tables created are forced to be innodb. This is not compatible with certain mysql settings which enforce a certain storage engine (https://www.percona.com/doc/percona-server/5.6/management/enforce_engine.html and https://mariadb.com/kb/en/mariadb/server-system-variables/#enforce_storage_engine). This patch just creates a table with the default storage engine.