### PR TITLE
fixed MHA online switch master,when orig_master and new_master is same. 

### DIFF
--- a/lib/MHA/MasterRotate.pm
+++ b/lib/MHA/MasterRotate.pm
@@ -621,6 +621,11 @@ sub do_master_online_switch {
   eval {
     $orig_master = identify_orig_master();
     my $new_master = identify_new_master($orig_master);
+    
+    if ($orig_master->{id} == $new_master->{id}){
+      croak "new_master is equal as orig_master, no need to switch.."
+    }
+    
     $log->info("** Phase 1: Configuration Check Phase completed.\n");
     $log->info();
 

--- a/lib/MHA/MasterRotate.pm
+++ b/lib/MHA/MasterRotate.pm
@@ -623,7 +623,7 @@ sub do_master_online_switch {
     my $new_master = identify_new_master($orig_master);
     
     if ($orig_master->{id} == $new_master->{id}){
-      croak "new_master is equal as orig_master, no need to switch.."
+      croak "new_master is equal as orig_master, no need to switch master!\n";
     }
     
     $log->info("** Phase 1: Configuration Check Phase completed.\n");


### PR DESCRIPTION
when you switch master online,masterha_master_switch --master_state=alive --conf=/etc/masterha/app1.conf --new_master_host=xxxx --new_master_port=xxx, you new_master_host and new_master_port is same as you orig_master_host orig_master_port,MHA will execute function reject_update,it cause master failover vip change and set read_only on it until master_pos_wait exit.