### PR TITLE
Fix masterha_check_repl

### DIFF
--- a/lib/MHA/ServerManager.pm
+++ b/lib/MHA/ServerManager.pm
@@ -407,19 +407,19 @@ sub validate_repl_filter($$) {
   my $replicate_wild_do_table;
   my $replicate_wild_ignore_table;
   foreach (@slaves) {
-    $replicate_do_db = $_->{Replicate_Do_DB} unless ($replicate_do_db);
+    $replicate_do_db = $_->{Replicate_Do_DB} unless (defined($replicate_do_db));
     $replicate_ignore_db = $_->{Replicate_Ignore_DB}
-      unless ($replicate_ignore_db);
-    $replicate_do_table = $_->{Replicate_Do_Table} unless ($replicate_do_table);
+      unless (defined($replicate_ignore_db));
+    $replicate_do_table = $_->{Replicate_Do_Table} unless (defined($replicate_do_table));
     $replicate_ignore_table = $_->{Replicate_Ignore_Table}
-      unless ($replicate_ignore_table);
+      unless (defined($replicate_ignore_table));
     $replicate_wild_do_table = $_->{Replicate_Wild_Do_Table}
-      unless ($replicate_wild_do_table);
+      unless (defined($replicate_wild_do_table));
     $replicate_wild_ignore_table = $_->{Replicate_Wild_Ignore_Table}
-      unless ($replicate_wild_ignore_table);
+      unless (defined($replicate_wild_ignore_table));
     if ( $_->{log_bin} ) {
-      $binlog_do_db     = $_->{Binlog_Do_DB}     unless ($binlog_do_db);
-      $binlog_ignore_db = $_->{Binlog_Ignore_DB} unless ($binlog_ignore_db);
+      $binlog_do_db     = $_->{Binlog_Do_DB}     unless (defined($binlog_do_db));
+      $binlog_ignore_db = $_->{Binlog_Ignore_DB} unless (defined($binlog_ignore_db));
     }
     if ( $replicate_do_db ne $_->{Replicate_Do_DB}
       || $replicate_ignore_db ne $_->{Replicate_Ignore_DB}

--- a/tests/t/t_filter_incorrect.sh
+++ b/tests/t/t_filter_incorrect.sh
@@ -24,6 +24,24 @@ fail_if_zero $0 $?
 ./run.sh
 fail_if_zero $0 $?
 
+./stop_s1.sh
+./start_s1.sh
+
+./stop_s4.sh
+./start_s4.sh --binlog-do-db=aaa
+masterha_check_repl --conf=$CONF > /dev/null 2>&1
+fail_if_zero $0 $?
+
+./run.sh
+fail_if_zero $0 $?
+
+./stop_s4.sh
+./start_s4.sh --replicate-ignore-db=aaa
+masterha_check_repl --conf=$CONF > /dev/null 2>&1
+fail_if_zero $0 $?
+
+./run.sh
+fail_if_zero $0 $?
 
 echo "$0 [Pass]"
 


### PR DESCRIPTION
`masterha_check_repl` has not worked
when replication filters are given to only tailing servers,
like test cases added to tests/t/t_filter_incorrect.sh.

This is because perl evaluates the empty string as `false` and
`unless` block is executed despite another server has a configuration
to declare that it never filters.

For example, there are three slaves and
only last server has a filtering setting for replicate_do_db,
`masterha_check_repl` succeeds like the followings.

1. the first slave does not filter and current replicate_do_db is undefined
    * replicate_do_db is set to $_->{Replicate_Do_DB}(empty string) and
    * replicate_do_db ne $_->{Replicate_Do_DB} is false
2. the second slave does not filter and current replicate_do_db is ""
    * replicate_do_db is set to $_->{Replicate_Do_DB}(empty string) and
    * replicate_do_db ne $_->{Replicate_Do_DB} is false
3. the third slave filters and current replicate_do_db is ""
    * replicate_do_db is set to $_->{Replicate_Do_DB}(some db) and
    * replicate_do_db ne $_->{Replicate_Do_DB} is false