### PR TITLE
Optionally skip the major version check

### DIFF
--- a/lib/MHA/Config.pm
+++ b/lib/MHA/Config.pm
@@ -31,7 +31,7 @@ use MHA::NodeUtil;
 use MHA::ManagerConst;
 
 my @PARAM_ARRAY =
-  qw/ hostname ip port ssh_host ssh_ip ssh_port ssh_connection_timeout ssh_options node_label candidate_master no_master ignore_fail skip_init_ssh_check skip_reset_slave user password repl_user repl_password disable_log_bin master_pid_file handle_raw_binlog ssh_user remote_workdir master_binlog_dir log_level manager_workdir manager_log check_repl_delay check_repl_filter latest_priority multi_tier_slave ping_interval ping_type secondary_check_script master_ip_failover_script master_ip_online_change_script shutdown_script report_script init_conf_load_script client_bindir client_libdir use_gtid_auto_pos/;
+  qw/ hostname ip port ssh_host ssh_ip ssh_port ssh_connection_timeout ssh_options node_label candidate_master no_master ignore_fail skip_init_ssh_check skip_reset_slave user password repl_user repl_password disable_log_bin master_pid_file handle_raw_binlog ssh_user remote_workdir master_binlog_dir log_level manager_workdir manager_log check_repl_delay check_repl_filter latest_priority multi_tier_slave ping_interval ping_type secondary_check_script master_ip_failover_script master_ip_online_change_script shutdown_script report_script init_conf_load_script client_bindir client_libdir use_gtid_auto_pos skip_version_check/;
 my %PARAM;
 for (@PARAM_ARRAY) { $PARAM{$_} = 1; }
 
@@ -262,6 +262,12 @@ sub parse_server {
   $value{skip_init_ssh_check} = $param_arg->{skip_init_ssh_check};
   $value{skip_init_ssh_check} = 0
     if ( !defined( $value{skip_init_ssh_check} ) );
+
+  $value{skip_version_check} = $param_arg->{skip_version_check};
+  $value{skip_version_check} = $default->{skip_version_check}
+    if ( !defined( $value{skip_version_check} ) );
+  $value{skip_version_check} = 0
+    if ( !defined( $value{skip_version_check} ) );
 
   $value{ping_type} = $param_arg->{ping_type};
   if ( !defined( $value{ping_type} ) ) {

--- a/lib/MHA/Config.pm
+++ b/lib/MHA/Config.pm
@@ -264,8 +264,6 @@ sub parse_server {
     if ( !defined( $value{skip_init_ssh_check} ) );
 
   $value{skip_version_check} = $param_arg->{skip_version_check};
-  $value{skip_version_check} = $default->{skip_version_check}
-    if ( !defined( $value{skip_version_check} ) );
   $value{skip_version_check} = 0
     if ( !defined( $value{skip_version_check} ) );
 

--- a/lib/MHA/ServerManager.pm
+++ b/lib/MHA/ServerManager.pm
@@ -1157,7 +1157,7 @@ sub get_bad_candidate_masters($$$) {
     if (
          $_->{no_master} >= 1
       || $_->{log_bin} eq '0'
-      || $_->{oldest_major_version} eq '0'
+      || ($_->{oldest_major_version} eq '0' && $_->{skip_version_check} eq '0')
       || (
         $latest_slave
         && ( $check_replication_delay


### PR DESCRIPTION
Introduce a new configure variable to skip the major version check when choosing a slave to promote to master.

Even though it's unsupported, it will be possible to replace a 5.6 writer with a 5.7 writer, as long as you knowingly remove the safety checks with this configuration option.
