### PR TITLE
Added missing build dependency for libmodule-install-perl

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: mha4mysql-manager
 Section: perl
 Priority: optional
-Build-Depends: debhelper (>= 7.2.13)
+Build-Depends: debhelper (>= 7.2.13), libmodule-install-perl
 Build-Depends-Indep: perl
 Maintainer: Yoshinori Matsunobu <Yoshinori.Matsunobu@gmail.com>
 Standards-Version: 3.9.1


### PR DESCRIPTION
In `debian/control` there is forgotter dependency for `libmodule-install-perl`
Without this dependency build runs like this
```
[20:33:11][Step 1/2] + debuild --check-dirname-level 0 --no-tgz-check -kprius
[20:33:12][Step 1/2]  dpkg-buildpackage -rfakeroot -D -us -uc
[20:33:12][Step 1/2] dpkg-buildpackage: source package mha4mysql-manager
[20:33:12][Step 1/2] dpkg-buildpackage: source version 0.56-0
[20:33:12][Step 1/2] dpkg-buildpackage: source distribution squeeze
[20:33:12][Step 1/2] dpkg-buildpackage: source changed by Yoshinori Matsunobu <Yoshinori.Matsunobu@gmail.com>
[20:33:12][Step 1/2]  dpkg-source --before-build mha4mysql-manager
[20:33:12][Step 1/2] dpkg-buildpackage: host architecture amd64
[20:33:12][Step 1/2]  fakeroot debian/rules clean
[20:33:12][Step 1/2] dh clean
[20:33:12][Step 1/2]    dh_testdir
[20:33:12][Step 1/2]    dh_auto_clean
[20:33:13][Step 1/2]    dh_clean
[20:33:13][Step 1/2]  dpkg-source -b mha4mysql-manager
[20:33:13][Step 1/2] dpkg-source: warning: no source format specified in debian/source/format, see dpkg-source(1)
[20:33:13][Step 1/2] dpkg-source: warning: source directory 'mha4mysql-manager' is not <sourcepackage>-<upstreamversion> 'mha4mysql-manager-0.56'
[20:33:13][Step 1/2] dpkg-source: info: using source format `1.0'
[20:33:13][Step 1/2] dpkg-source: info: building mha4mysql-manager in mha4mysql-manager_0.56-0.tar.gz
[20:33:13][Step 1/2] dpkg-source: info: building mha4mysql-manager in mha4mysql-manager_0.56-0.dsc
[20:33:13][Step 1/2]  debian/rules build
[20:33:13][Step 1/2] dh build
[20:33:13][Step 1/2]    dh_testdir
[20:33:13][Step 1/2]    dh_auto_configure
[20:33:13][Step 1/2] Can't locate inc/Module/Install.pm in @INC (you may need to install the inc::Module::Install module) (@INC contains: /etc/perl /usr/local/lib/perl/5.18.2 /usr/local/share/perl/5.18.2 /usr/lib/perl5 /usr/share/perl5 /usr/lib/perl/5.18 /usr/share/perl/5.18 /usr/local/lib/site_perl .) at Makefile.PL line 1.
[20:33:13][Step 1/2] BEGIN failed--compilation aborted at Makefile.PL line 1.
[20:33:13][Step 1/2] dh_auto_configure: perl Makefile.PL INSTALLDIRS=vendor create_packlist=0 returned exit code 2
[20:33:13][Step 1/2] debuild: fatal error at line 1364:
[20:33:13][Step 1/2] dpkg-buildpackage -rfakeroot -D -us -uc failed
[20:33:13][Step 1/2] make: *** [build] Error 2
[20:33:13][Step 1/2] dpkg-buildpackage: error: debian/rules build gave error exit status 2
[20:33:13][Step 1/2] Process exited with code 29
[20:33:13][Step 1/2] Step Build package (Command Line) failed
```
So it is missing `inc::Module::Install` module.
If we add this dependency and then run
```
cd debian/
sudo /usr/lib/pbuilder/pbuilder-satisfydepends --control control
```
Package will be installed and then debuild runs smootly.