### PR TITLE
fix online_switch_mysql caused data inconsistency

### DIFF
--- a/lib/MHA/DBHelper.pm
+++ b/lib/MHA/DBHelper.pm
@@ -409,7 +409,11 @@ sub flush_tables_nolog($) {
 
 sub flush_tables_with_read_lock($) {
   my $self = shift;
-  return $self->execute(Flush_Tables_With_Read_Lock_SQL);
+  my $result = $self->execute(Set_Readonly_SQL);
+    if ($result) {
+       $result = $self->execute(Flush_Tables_With_Read_Lock_SQL);
+    }
+  return $result;
 }
 
 sub unlock_tables($) {


### PR DESCRIPTION
Our company use mha for mysql HA solution ,  but we find online_switch_mysql node will missing data for new master , some data is keep in origin master, cousing new master  slave  replication error. And we find the result is that when switch_mysql , mha will lock tables , but it it not read_only, when unlocking tables does, origin master will continuous excute sql which is bolocked by lock tables, So If I set read_only before locking tables,  all works well.