### PR TITLE
fix master host which  not include in  hosts file  will excute second…

### DIFF
--- a/bin/masterha_secondary_check
+++ b/bin/masterha_secondary_check
@@ -88,7 +88,7 @@ foreach my $monitoring_server (@monitoring_servers) {
   my $command =
 "ssh $MHA::ManagerConst::SSH_OPT_CHECK -p $ssh_port $ssh_user_host \"perl -e "
     . "\\\"use IO::Socket::INET; my \\\\\\\$sock = IO::Socket::INET->new"
-    . "(PeerAddr => \\\\\\\"$master_host\\\\\\\", PeerPort=> $master_port, "
+    . "(PeerAddr => \\\\\\\"$master_ip\\\\\\\", PeerPort=> $master_port, "
     . "Proto =>'tcp', Timeout => $timeout); if(\\\\\\\$sock) { close(\\\\\\\$sock); "
     . "exit 3; } exit 0;\\\" \"";
   my $ret = system($command);


### PR DESCRIPTION
…ary_check failed

we find something shold be better during checking masterha_secondary_check on MHA node.

## command
secondary_check_script=masterha_secondary_check -s 172.17.16.245 -s 172.17.2.201 --port=60122 --user=mysql --master_host=xxx-db-0001 --master_ip=172.17.16.119 --master_port=3306

We find it will login remote (-s) host and excute perl scripts  [ 'ssh_port $ssh_user_host 'perl -e xxxxx ' ] to check mysql status, But if you dont config master host in  hosts file on every node, so remote monitor server could not find this host to ip, it will failed and return  "Monitoring server $monitoring_server is reachable, Master is not writable from $monitoring_server. OK." , this leading to  masterha_secondary_check return 2, and not failover.(use IO::Socket: xxx $master_host )   So if you change perl script  master_host  ----> master_ip , everthing is fine.

This is a very important detail, please seriously consider