### PR TITLE
新しいlibdbd-mysql-perlは[$host]のsyntaxを許容する

### DIFF
--- a/lib/MHA/DBHelper.pm
+++ b/lib/MHA/DBHelper.pm
@@ -152,7 +152,7 @@ sub connect_util {
   my $port     = shift;
   my $user     = shift;
   my $password = shift;
-  my $dsn      = "DBI:mysql:;host=[$host];port=$port;mysql_connect_timeout=1";
+  my $dsn      = "DBI:mysql:;host=$host;port=$port;mysql_connect_timeout=1";
   my $dbh      = DBI->connect( $dsn, $user, $password, { PrintError => 0 } );
   return $dbh;
 }
@@ -195,7 +195,7 @@ sub connect {
 
   $self->{dbh} = undef;
   unless ( $self->{dsn} ) {
-    $self->{dsn} = "DBI:mysql:;host=[$host];port=$port;mysql_connect_timeout=4";
+    $self->{dsn} = "DBI:mysql:;host=$host;port=$port;mysql_connect_timeout=4";
   }
   my $defaults = {
     PrintError => 0,

--- a/lib/MHA/HealthCheck.pm
+++ b/lib/MHA/HealthCheck.pm
@@ -95,7 +95,7 @@ sub connect {
   }
   my $log = $self->{logger};
   $self->{dbh} = DBI->connect(
-    "DBI:mysql:;host=[$self->{ip}];"
+    "DBI:mysql:;host=$self->{ip};"
       . "port=$self->{port};mysql_connect_timeout=$connect_timeout",
     $self->{user},
     $self->{password},


### PR DESCRIPTION
http://blog.takanabe.tokyo/2016/05/04/2410/

MHAのDBD利用箇所を読んで見る。

MHAはPerlで書かれておりデータベースとのインタフェースにはDBD-mysqlが使われている。データベースとの接続は、DBHelper.pmのconnect関数で行っている。

sub connect {
  my $self        = shift;
  my $host        = shift;
  my $port        = shift;
  my $user        = shift;
  my $password    = shift;
  my $raise_error = shift;
  my $max_retries = shift;
  $raise_error = 0 if ( !defined($raise_error) );
  $max_retries = 2 if ( !defined($max_retries) );

  $self->{dbh} = undef;
  unless ( $self->{dsn} ) {
    $self->{dsn} = "DBI:mysql:;host=[$host];port=$port;mysql_connect_timeout=4";
  }
確かにdsnの定義でhost=[$host]と書かれている。これ、[]外せばエラーなくなるんじゃないか？と思い、試しに外してレプリケーションテストコマンドを実行するとエラーが無くなり動作確認が終了した。

新しいlibdbd-mysql-perlは[$host]のsyntaxを許容する

エラーが発生する理由が、DBI:mysql:;host=[$host];port=$port;mysql_connect_timeout=4のようにホストのsyntaxで[]を使っているせいだとわかった。

この変更が加えられたコミットを見るとどうやらlibdbd-mysql-perlがipv6対応のためにホストをブラケットで囲う記法を追加しており、それに追従するためのようだ。

libdbd-mysql-perlの方の変更を見るとMHAのDBHelper.pmのブラケットを追加した人が、ブラケット記法について説明を追加していたり、ipv6アドレスがhostに渡された時のブラケットの処理が追加されていたり大きな変更が入っている。

この変更が含まれていないバージョンのlibdbd-mysql-perlを使うと、最新のMHAは正常に動作しないので注意が必要だ。