### PR TITLE
 ipv4 address with brackets causes error on connection.

### DIFF
--- a/lib/MHA/DBHelper.pm
+++ b/lib/MHA/DBHelper.pm
@@ -152,7 +152,8 @@ sub connect_util {
   my $port     = shift;
   my $user     = shift;
   my $password = shift;
-  my $dsn      = "DBI:mysql:;host=[$host];port=$port;mysql_connect_timeout=1";
+  my $dsn_host = $host =~ m{:} ? '[' . $host . ']' : $host;
+  my $dsn      = "DBI:mysql:;host=$dsn_host;port=$port;mysql_connect_timeout=1";
   my $dbh      = DBI->connect( $dsn, $user, $password, { PrintError => 0 } );
   return $dbh;
 }
@@ -195,7 +196,8 @@ sub connect {
 
   $self->{dbh} = undef;
   unless ( $self->{dsn} ) {
-    $self->{dsn} = "DBI:mysql:;host=[$host];port=$port;mysql_connect_timeout=4";
+    my $dsn_host = $host =~ m{:} ? '[' . $host . ']' : $host;
+    $self->{dsn} = "DBI:mysql:;host=$dsn_host;port=$port;mysql_connect_timeout=4";
   }
   my $defaults = {
     PrintError => 0,

--- a/lib/MHA/HealthCheck.pm
+++ b/lib/MHA/HealthCheck.pm
@@ -94,8 +94,9 @@ sub connect {
     $raise_error = 0;
   }
   my $log = $self->{logger};
+  my $dsn_host = $self->{ip} =~ m{:} ? '[' . $self->{ip} . ']' : $self->{ip};
   $self->{dbh} = DBI->connect(
-    "DBI:mysql:;host=[$self->{ip}];"
+    "DBI:mysql:;host=$dsn_host;"
       . "port=$self->{port};mysql_connect_timeout=$connect_timeout",
     $self->{user},
     $self->{password},

--- a/tests/t/bulk_tran_insert.pl
+++ b/tests/t/bulk_tran_insert.pl
@@ -7,7 +7,7 @@ use DBI;
 my ( $port, $user, $pass, $start, $stop, $commit_interval ) = @ARGV;
 my $pk             = $start;
 my $committed_rows = 0;
-my $dsn            = "DBI:mysql:test;host=[127.0.0.1];port=$port";
+my $dsn            = "DBI:mysql:test;host=127.0.0.1;port=$port";
 my $dbh            = DBI->connect( $dsn, $user, $pass );
 if ( $commit_interval == 1 ) {
   $dbh->do("SET AUTOCOMMIT=1");

--- a/tests/t/insert.pl
+++ b/tests/t/insert.pl
@@ -7,7 +7,7 @@ use DBI;
 my ( $port, $user, $pass, $start, $stop, $single_tran, $rollback ) = @ARGV;
 $rollback = 0 if ( !defined($rollback) );
 
-my $dsn = "DBI:mysql:test;host=[127.0.0.1];port=$port";
+my $dsn = "DBI:mysql:test;host=127.0.0.1;port=$port";
 my $dbh = DBI->connect( $dsn, $user, $pass );
 
 my $sth;

--- a/tests/t/insert_binary.pl
+++ b/tests/t/insert_binary.pl
@@ -21,7 +21,7 @@ read($in, $buf, -s $file);
 close($in);
 unlink $file;
 
-my $dsn = "DBI:mysql:test;host=[127.0.0.1];port=$port";
+my $dsn = "DBI:mysql:test;host=127.0.0.1;port=$port";
 my $dbh = DBI->connect( $dsn, $user, $pass );
 
 my $value= $buf;

--- a/tests/t/tran_insert.pl
+++ b/tests/t/tran_insert.pl
@@ -7,7 +7,7 @@ use DBI;
 my ( $port, $user, $pass, $start, $stop, $commit_interval ) = @ARGV;
 my $pk             = $start;
 my $committed_rows = 0;
-my $dsn            = "DBI:mysql:test;host=[127.0.0.1];port=$port";
+my $dsn            = "DBI:mysql:test;host=127.0.0.1;port=$port";
 my $dbh            = DBI->connect( $dsn, $user, $pass );
 if ( $commit_interval == 1 ) {
   $dbh->do("SET AUTOCOMMIT=1");


### PR DESCRIPTION
 ipv4 address with brackets causes error on connection.
 add brackets only when ip contains ':'.