### PR TITLE
Add command line option to check for errant transaction

### DIFF
--- a/lib/MHA/DBHelper.pm
+++ b/lib/MHA/DBHelper.pm
@@ -111,6 +111,8 @@ use constant Master_Pos_Wait_NoTimeout_SQL =>
   "SELECT MASTER_POS_WAIT(?,?,0) AS Result";
 use constant Gtid_Wait_NoTimeout_SQL =>
   "SELECT WAIT_UNTIL_SQL_THREAD_AFTER_GTIDS(?,0) AS Result";
+use constant Gtid_Subset_SQL  => "SELECT GTID_SUBSET(?,?) AS Result";
+use constant Gtid_Substract_SQL  => "SELECT GTID_SUBTRACT(?,?) AS Result";
 use constant Get_Connection_Id_SQL  => "SELECT CONNECTION_ID() AS Value";
 use constant Flush_Tables_Nolog_SQL => "FLUSH NO_WRITE_TO_BINLOG TABLES";
 use constant Flush_Tables_With_Read_Lock_SQL => "FLUSH TABLES WITH READ LOCK";
@@ -874,6 +876,26 @@ sub gtid_wait($$) {
   my $exec_gtid = shift;
   my $sth       = $self->{dbh}->prepare(Gtid_Wait_NoTimeout_SQL);
   $sth->execute($exec_gtid);
+  my $href = $sth->fetchrow_hashref;
+  return $href->{Result};
+}
+
+sub gtid_subset($$$) {
+  my $self        = shift;
+  my $gtid_subset = shift;
+  my $gtid_set    = shift;
+  my $sth         = $self->{dbh}->prepare(Gtid_Subset_SQL);
+  $sth->execute( $gtid_subset, $gtid_set );
+  my $href = $sth->fetchrow_hashref;
+  return $href->{Result};
+}
+
+sub gtid_substract($$$) {
+  my $self        = shift;
+  my $gtid_set    = shift;
+  my $gtid_subset = shift;
+  my $sth         = $self->{dbh}->prepare(Gtid_Substract_SQL);
+  $sth->execute( $gtid_set, $gtid_subset );
   my $href = $sth->fetchrow_hashref;
   return $href->{Result};
 }

--- a/lib/MHA/MasterRotate.pm
+++ b/lib/MHA/MasterRotate.pm
@@ -40,6 +40,7 @@ use Parallel::ForkManager;
 my $g_global_config_file = $MHA::ManagerConst::DEFAULT_GLOBAL_CONF;
 my $g_config_file;
 my $g_check_only;
+my $g_check_for_errant_transactions;
 my $g_new_master_host;
 my $g_new_master_port = 3306;
 my $g_workdir;
@@ -622,6 +623,11 @@ sub do_master_online_switch {
   eval {
     $orig_master = identify_orig_master();
     my $new_master = identify_new_master($orig_master);
+
+    if ($g_check_for_errant_transactions) {
+      $_server_manager->check_for_errant_transactions( $orig_master, $new_master );
+    }
+
     $log->info("** Phase 1: Configuration Check Phase completed.\n");
     $log->info();
 
@@ -724,6 +730,7 @@ sub main {
     'remove_dead_master_conf'  => \$g_remove_orig_master_conf,
     'remove_orig_master_conf'  => \$g_remove_orig_master_conf,
     'flush_tables=i'           => \$g_flush_tables,
+    'check_for_errant_transactions' => \$g_check_for_errant_transactions,
   );
   if ( $#ARGV >= 0 ) {
     print "Unknown options: ";


### PR DESCRIPTION
This errant transactions check is only performed if `--check_for_errant_transactions` is present on `masterha_master_switch` command line, default behavior is unchanged.

If errant transactions are found, switch-over is aborted during Phase 1 (Configuration Check Phase) and a fix is suggested using `mysqlslavetrx`. 

This is to prevent switch-over to get stuck after the CHANGE MASTER statement with replication error 1236.