### PR TITLE
Add option for ignoring "no_master" setting when manually failover

### DIFF
--- a/lib/MHA/ManagerConst.pm
+++ b/lib/MHA/ManagerConst.pm
@@ -24,7 +24,7 @@ use warnings FATAL => 'all';
 
 use MHA::NodeConst;
 
-our $VERSION          = '0.58';
+our $VERSION          = '0.59';
 our $NODE_MIN_VERSION = '0.54';
 
 our @ALIVE_ERROR_CODES = (

--- a/lib/MHA/MasterFailover.pm
+++ b/lib/MHA/MasterFailover.pm
@@ -56,6 +56,7 @@ my $g_skip_change_master;
 my $g_skip_disable_read_only;
 my $g_wait_until_gtid_in_sync = 1;
 my $g_ignore_binlog_server_error;
+my $g_new_master_ignore_no_master = 0;
 my $_real_ssh_reachable;
 my $_saved_file_suffix;
 my $_start_datetime;
@@ -147,6 +148,9 @@ sub check_settings($) {
   $_status_handler->update_status($MHA::ManagerConst::ST_FAILOVER_RUNNING_S);
 
   $_server_manager = new MHA::ServerManager( servers => \@servers_config );
+  if ($g_new_master_ignore_no_master == 1) {
+    $_server_manager->set_ignore_no_master($g_new_master_ignore_no_master);
+  }
   $_server_manager->set_logger($log);
   if ($g_interactive) {
     $_server_manager->connect_all_and_read_server_status();
@@ -2255,6 +2259,7 @@ sub main {
     'skip_disable_read_only'     => \$g_skip_disable_read_only,
     'wait_until_gtid_in_sync=i'  => \$g_wait_until_gtid_in_sync,
     'ignore_binlog_server_error' => \$g_ignore_binlog_server_error,
+    'g_new_master_ignore_no_master' => \$g_new_master_ignore_no_master,
   );
   setpgrp( 0, $$ ) unless ($g_interactive);
 
@@ -2274,6 +2279,9 @@ sub main {
     $master_port = 3306;
     print
       "--dead_master_port=<dead_master_port> is not set. Using $master_port.\n";
+  }
+  if ($g_new_master_ignore_no_master == 1) {
+    print "--select new master will ignore no_master section.\n";
   }
 
   $_dead_master_arg{hostname} = $master_host;

--- a/lib/MHA/MasterFailover.pm
+++ b/lib/MHA/MasterFailover.pm
@@ -2259,7 +2259,7 @@ sub main {
     'skip_disable_read_only'     => \$g_skip_disable_read_only,
     'wait_until_gtid_in_sync=i'  => \$g_wait_until_gtid_in_sync,
     'ignore_binlog_server_error' => \$g_ignore_binlog_server_error,
-    'g_new_master_ignore_no_master' => \$g_new_master_ignore_no_master,
+    'new_master_ignore_no_master' => \$g_new_master_ignore_no_master,
   );
   setpgrp( 0, $$ ) unless ($g_interactive);
 

--- a/lib/MHA/MasterFailover.pm
+++ b/lib/MHA/MasterFailover.pm
@@ -2259,7 +2259,7 @@ sub main {
     'skip_disable_read_only'     => \$g_skip_disable_read_only,
     'wait_until_gtid_in_sync=i'  => \$g_wait_until_gtid_in_sync,
     'ignore_binlog_server_error' => \$g_ignore_binlog_server_error,
-    'new_master_ignore_no_master' => \$g_new_master_ignore_no_master,
+    'new_master_ignore_no_master=i' => \$g_new_master_ignore_no_master,
   );
   setpgrp( 0, $$ ) unless ($g_interactive);
 

--- a/lib/MHA/ServerManager.pm
+++ b/lib/MHA/ServerManager.pm
@@ -43,9 +43,16 @@ sub new {
     orig_master      => undef,
     new_master       => undef,
     logger           => undef,
+    ignore_no_master => 0,
     @_,
   };
   return bless $self, $class;
+}
+
+sub set_ignore_no_master($$) {
+  my $self        = shift;
+  my $ignore_no_master_setting = shift;
+  $self->{ignore_no_master} = $ignore_no_master_setting;
 }
 
 sub set_servers($$) {
@@ -1155,7 +1162,7 @@ sub get_bad_candidate_masters($$$) {
   my @ret_servers = ();
   foreach (@servers) {
     if (
-         $_->{no_master} >= 1
+         ($self->{ignore_no_master} == 0 && $_->{no_master} >= 1)
       || $_->{log_bin} eq '0'
       || $_->{oldest_major_version} eq '0'
       || (


### PR DESCRIPTION
## Abstract
Lightly changes are made to provider an optional "force-switch" when manually failover the Mysql cluster.

## Reason
The decision would be taken for some scenarios as below:
1. I have auto-failover running as well as I want to manually switch the master by some time. And I'd like it to be a "forced-switch" rather than following the original configuration.
2. Even if the delay is high, "no_master" is made by MHA manager itself(as the new_master I pointed to, might be a "oldest server"), I would have the opportunity to ignore it, as long as the "recover_new_master" works.

## Changes
1. An option input for ignoring the "no_master" keyword, so that my target new master is always guaranteed to be chosen for a new epoch
2. Additional global variable "new_master_ignore_no_master" will have effect on the decider whether "candidate is bad or not"
3. A field and "Set" method is added to "ServerManager.pm"