### PR TITLE
Update HealthCheck.pm

### DIFF
--- a/lib/MHA/HealthCheck.pm
+++ b/lib/MHA/HealthCheck.pm
@@ -642,7 +642,7 @@ sub wait_until_unreachable($) {
       $self->{_tstart} = [gettimeofday];
       if ( $self->{_need_reconnect} ) {
         my ( $rc, $mysql_err ) =
-          $self->connect( undef, undef, undef, undef, undef, $error_count );
+          $self->connect( undef, undef, undef, undef, undef, 0 );
         if ($rc) {
           if ($mysql_err) {
             if (


### PR DESCRIPTION
I want to know why use error_count to forbid re-lock monitor when connection loss?
I set pass 0 to connect event if connection loss, so it will relock again. 
Is it OK for this change?